### PR TITLE
Update correlation to handle single time series

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Features
 - ``standardize`` function moved to stats. (:pr:`52`) `Riley X. Brady`_.
 - ``loadutils`` removed (:pr:`52`) `Riley X. Brady`_.
 - ``calculate_compatible_emissions`` following Jones et al. 2013  (:pr:`54`) `Aaron Spring`_
-- Update ``corr`` to broadcast ``x`` and ``y`` such that a single time series can be correlated across a grid. (:pr: ###) `Riley X. Brady`_.
+- Update ``corr`` to broadcast ``x`` and ``y`` such that a single time series can be correlated across a grid. (:pr:`58`) `Riley X. Brady`_.
 
 Internals/Minor Fixes
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,18 +2,19 @@
 Changelog History
 =================
 
-esm_analysis v1.0.3 (2019-07-##)
+esm_analysis v1.0.3 (2019-08-##)
 ================================
 
 Features
 --------
-- ``co2_sol`` and ``schmidt`` now can be computed on grids and does not do time-averaging (:pr:`45`) `Riley X. Brady`_.
+- ``co2_sol`` and ``schmidt`` now can be computed on grids and do not do time-averaging (:pr:`45`) `Riley X. Brady`_.
 - ``temp_decomp_takahashi`` now returns a dataset with thermal/non-thermal components (:pr:`45`) `Riley X. Brady`_.
 - ``temporal`` module that includes a ``to_annual()`` function for weighted temporal resampling (:pr:`50`) `Riley X. Brady`_.
 - ``filtering`` module renamed to ``spatial`` and ``find_indices`` made public. (:pr:`52`) `Riley X. Brady`_.
 - ``standardize`` function moved to stats. (:pr:`52`) `Riley X. Brady`_.
 - ``loadutils`` removed (:pr:`52`) `Riley X. Brady`_.
-- compatible emissions (:pr:`54`) `Aaron Spring`_
+- ``calculate_compatible_emissions`` following Jones et al. 2013  (:pr:`54`) `Aaron Spring`_
+- Update ``corr`` to broadcast ``x`` and ``y`` such that a single time series can be correlated across a grid. (:pr: ###) `Riley X. Brady`_.
 
 Internals/Minor Fixes
 ---------------------
@@ -39,3 +40,4 @@ esmtools v1.0.0 (2019-07-25)
 Formally releases ``esmtools`` on pip for easy installing by other packages.
 
 .. _`Riley X. Brady`: https://github.com/bradyrx
+.. _`Aaron Spring`: https://github.com/aaronspring

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -26,3 +26,4 @@ dependencies:
   - pip:
       - sphinxcontrib-napoleon
       - sphinx_automodapi
+      - pre-commit

--- a/docs/source/api/esm_analysis.carbon.calculate_compatible_emissions.rst
+++ b/docs/source/api/esm_analysis.carbon.calculate_compatible_emissions.rst
@@ -1,0 +1,6 @@
+calculate_compatible_emissions
+==============================
+
+.. currentmodule:: esm_analysis.carbon
+
+.. autofunction:: calculate_compatible_emissions

--- a/docs/source/api/esm_analysis.carbon.get_iam_emissions.rst
+++ b/docs/source/api/esm_analysis.carbon.get_iam_emissions.rst
@@ -1,0 +1,6 @@
+get_iam_emissions
+=================
+
+.. currentmodule:: esm_analysis.carbon
+
+.. autofunction:: get_iam_emissions

--- a/docs/source/api/esm_analysis.carbon.plot_compatible_emissions.rst
+++ b/docs/source/api/esm_analysis.carbon.plot_compatible_emissions.rst
@@ -1,0 +1,6 @@
+plot_compatible_emissions
+=========================
+
+.. currentmodule:: esm_analysis.carbon
+
+.. autofunction:: plot_compatible_emissions

--- a/docs/source/api/esm_analysis.conversions.convert_CO2_flux.rst
+++ b/docs/source/api/esm_analysis.conversions.convert_CO2_flux.rst
@@ -1,6 +1,0 @@
-convert_CO2_flux
-================
-
-.. currentmodule:: esm_analysis.conversions
-
-.. autofunction:: convert_CO2_flux

--- a/docs/source/api/esm_analysis.filtering.extract_region.rst
+++ b/docs/source/api/esm_analysis.filtering.extract_region.rst
@@ -1,6 +1,0 @@
-extract_region
-==============
-
-.. currentmodule:: esm_analysis.filtering
-
-.. autofunction:: extract_region

--- a/esm_analysis/stats.py
+++ b/esm_analysis/stats.py
@@ -410,7 +410,7 @@ def corr(x, y, dim='time', lead=0, return_p=False):
     # Broadcasts a time series to the same coordinates/size as the grid. If they
     # are both grids, this function does nothing and isn't expensive.
     x, y = xr.broadcast(x, y)
-    
+
     # Negative lead should have y lead x.
     if lead < 0:
         lead = np.abs(lead)

--- a/esm_analysis/stats.py
+++ b/esm_analysis/stats.py
@@ -370,19 +370,13 @@ def linear_regression(da, dim='time', interpolate_na=False, compact=True, psig=N
 
 
 @check_xarray(0)
-def corr(x, y, dim='time', lag=0, return_p=False):
+def corr(x, y, dim='time', lead=0, return_p=False):
     """
     Computes the Pearson product-momment coefficient of linear correlation.
-    (See autocorr for autocorrelation/lag for one time series)
+
     This version calculates the effective degrees of freedom, accounting
     for autocorrelation within each time series that could fluff the
     significance of the correlation.
-
-    NOTE: If lag is not zero, x predicts y. In other words, the time series for
-    x is stationary, and y slides to the left. Or, y stays in place and x
-    slides to the right.
-    This function is written to accept a dataset of arbitrary number of
-    dimensions (e.g., lat, lon, depth).
 
     Parameters
     ----------
@@ -390,8 +384,9 @@ def corr(x, y, dim='time', lag=0, return_p=False):
         time series being correlated (can be multi-dimensional)
     dim : str (default 'time')
         Correlation dimension
-    lag : int (default 0)
-        Lag to apply to correlation, with x predicting y.
+    lead : int (default 0)
+        If lead > 0, x leads y by that many time steps.
+        If lead < 0, x lags y by that many time steps.
     return_p : boolean (default False)
         If true, return both r and p
 
@@ -412,7 +407,16 @@ def corr(x, y, dim='time', lag=0, return_p=False):
     fluxes in Eastern Boundary Upwelling Systems, Biogeosciences Discuss.,
     https://doi.org/10.5194/bg-2018-415, in review, 2018.
     """
-    return st.corr(x, y, dim=dim, lag=lag, return_p=return_p)
+    # Broadcasts a time series to the same coordinates/size as the grid. If they
+    # are both grids, this function does nothing and isn't expensive.
+    x, y = xr.broadcast(x, y)
+    
+    # Negative lead should have y lead x.
+    if lead < 0:
+        lead = np.abs(lead)
+        return st.corr(y, x, dim=dim, lag=lead, return_p=return_p)
+    else:
+        return st.corr(x, y, dim=dim, lag=lead, return_p=return_p)
 
 
 @check_xarray(0)

--- a/esm_analysis/tests/test_stats.py
+++ b/esm_analysis/tests/test_stats.py
@@ -1,27 +1,40 @@
 import numpy as np
 import xarray as xr
 from esm_analysis.stats import corr
+import pytest
 
 
+@pytest.fixture()
 def gridded_ts_da():
     """Mock data of gridded time series."""
-    data = np.random.rand(120, 10, 10)
-    da = xr.DataArray(data, dims=['time', 'lat', 'lon'])
-    # Monthly resolution time axis for 10 years.
-    da['time'] = np.arange('1990-01', '2000-01', dtype='datetime64[M]')
-    return da
+    # Wrapper so fixture can be called multiple times.
+    # https://alysivji.github.io/pytest-fixures-with-function-arguments.html
+    def _gen_data():
+        data = np.random.rand(120, 10, 10)
+        da = xr.DataArray(data, dims=['time', 'lat', 'lon'])
+        # Monthly resolution time axis for 10 years.
+        da['time'] = np.arange('1990-01', '2000-01', dtype='datetime64[M]')
+        return da
+
+    return _gen_data
 
 
+@pytest.fixture()
 def ts_monthly_da():
     """Mock time series at monthly resolution for ten years."""
-    data = np.random.rand(120)
-    da = xr.DataArray(data, dims=['time'])
-    # Monthly resolution time axis for 10 years.
-    da['time'] = np.arange('1990-01', '2000-01', dtype='datetime64[M]')
-    return da
+    # Wrapper so fixture can be called multiple times.
+    # https://alysivji.github.io/pytest-fixures-with-function-arguments.html
+    def _gen_data():
+        data = np.random.rand(120)
+        da = xr.DataArray(data, dims=['time'])
+        # Monthly resolution time axis for 10 years.
+        da['time'] = np.arange('1990-01', '2000-01', dtype='datetime64[M]')
+        return da
+
+    return _gen_data
 
 
-def test_corr_two_grids():
+def test_corr_two_grids(gridded_ts_da):
     """Tests that correlations between two grids work."""
     x = gridded_ts_da()
     y = gridded_ts_da()
@@ -30,7 +43,7 @@ def test_corr_two_grids():
     assert not corrcoeff.isnull().any()
 
 
-def test_corr_grid_and_ts():
+def test_corr_grid_and_ts(ts_monthly_da, gridded_ts_da):
     """Tests that correlation works between a grid and a time series."""
     x = ts_monthly_da()
     y = gridded_ts_da()
@@ -39,7 +52,7 @@ def test_corr_grid_and_ts():
     assert not corrcoeff.isnull().any()
 
 
-def test_corr_lead():
+def test_corr_lead(gridded_ts_da):
     """Tests positive lead for correlation."""
     x = gridded_ts_da()
     y = gridded_ts_da()
@@ -48,7 +61,7 @@ def test_corr_lead():
     assert not corrcoeff.isnull().any()
 
 
-def test_corr_lag():
+def test_corr_lag(gridded_ts_da):
     """Tests negative lead for correlation."""
     x = gridded_ts_da()
     y = gridded_ts_da()
@@ -57,7 +70,7 @@ def test_corr_lag():
     assert not corrcoeff.isnull().any()
 
 
-def test_corr_return_p():
+def test_corr_return_p(gridded_ts_da):
     """Tests that p-value is returned properly for correlation."""
     x = gridded_ts_da()
     y = gridded_ts_da()

--- a/esm_analysis/tests/test_stats.py
+++ b/esm_analysis/tests/test_stats.py
@@ -1,17 +1,66 @@
-import climpred
-import pytest
-from esm_analysis.stats import linear_regression
+import numpy as np
+import xarray as xr
+from esm_analysis.stats import corr
 
 
-@pytest.fixture
-def single_ts():
-    da = climpred.tutorial.load_dataset('FOSI-SST')
-    da = da['SST']
+def gridded_ts_da():
+    """Mock data of gridded time series."""
+    data = np.random.rand(120, 10, 10)
+    da = xr.DataArray(data, dims=['time', 'lat', 'lon'])
+    # Monthly resolution time axis for 10 years.
+    da['time'] = np.arange('1990-01', '2000-01', dtype='datetime64[M]')
     return da
 
 
-def test_linear_regression(single_ts):
-    """Tests that linear regression works on a single time series."""
-    results = linear_regression(single_ts, dim='time')
-    for v in results.data_vars:
-        assert results[v]
+def ts_monthly_da():
+    """Mock time series at monthly resolution for ten years."""
+    data = np.random.rand(120)
+    da = xr.DataArray(data, dims=['time'])
+    # Monthly resolution time axis for 10 years.
+    da['time'] = np.arange('1990-01', '2000-01', dtype='datetime64[M]')
+    return da
+
+
+def test_corr_two_grids():
+    """Tests that correlations between two grids work."""
+    x = gridded_ts_da()
+    y = gridded_ts_da()
+    corrcoeff = corr(x, y, dim='time')
+    # check that there's no NaNs in the resulting output.
+    assert not corrcoeff.isnull().any()
+
+
+def test_corr_grid_and_ts():
+    """Tests that correlation works between a grid and a time series."""
+    x = ts_monthly_da()
+    y = gridded_ts_da()
+    corrcoeff = corr(x, y, dim='time')
+    # check that there's no NaNs in the resulting output.
+    assert not corrcoeff.isnull().any()
+
+
+def test_corr_lead():
+    """Tests positive lead for correlation."""
+    x = gridded_ts_da()
+    y = gridded_ts_da()
+    corrcoeff = corr(x, y, dim='time', lead=3)
+    # check that there's no NaNs in the resulting output.
+    assert not corrcoeff.isnull().any()
+
+
+def test_corr_lag():
+    """Tests negative lead for correlation."""
+    x = gridded_ts_da()
+    y = gridded_ts_da()
+    corrcoeff = corr(x, y, dim='time', lead=-3)
+    # check that there's no NaNs in the resulting output.
+    assert not corrcoeff.isnull().any()
+
+
+def test_corr_return_p():
+    """Tests that p-value is returned properly for correlation."""
+    x = gridded_ts_da()
+    y = gridded_ts_da()
+    corrcoeff, pval = corr(x, y, dim='time', return_p=True)
+    # check that there's no NaNs in the resulting output.
+    assert not (corrcoeff.isnull().any()) & (pval.isnull().any())


### PR DESCRIPTION
# Description

This PR allows a single time series to be correlated with a grid via `xr.broadcast`. It also changes the `lag` keyword to `lead` for more clarity and allows negative values. 

E.g.,
lead=3 has x lead y by 3 time steps.
lead=-3 has x lag y by 3 time steps.

Fixes # https://github.com/bradyrx/esm_analysis/issues/29

## Type of change

Please delete options that are not relevant.

-   [X]  Bug fix (non-breaking change which fixes an issue)
-   [X]  New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've tested with some CESM output to compare a gridded output to a single climate index time series.

## Checklist (while developing)

-   [X ]  I have added docstrings to all new functions.
-   [X]  I have commented my code, particularly in hard-to-understand areas
-   [x]  Tests added for `pytest`, if necessary.
-   [X]  I have updated the sphinx documentation, if necessary.

## Pre-Merge Checklist (final steps)

-   [ ]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.
-   [ ]  I have run `make html` on the documents to make sure example notebooks still compile.
