### PR TITLE
Refactor `grid` module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog History
 =================
 
-esm_analysis v1.0.3 (2019-08-##)
+esm_analysis v1.1 (2019-09-##)
 ================================
 
 Features
@@ -15,6 +15,7 @@ Features
 - ``loadutils`` removed (:pr:`52`) `Riley X. Brady`_.
 - ``calculate_compatible_emissions`` following Jones et al. 2013  (:pr:`54`) `Aaron Spring`_
 - Update ``corr`` to broadcast ``x`` and ``y`` such that a single time series can be correlated across a grid. (:pr:`58`) `Riley X. Brady`_.
+- ``convert_lon_to_180to180`` and ``convert_lon_to_0to360`` now wrapped with ``convert_lon`` and now supports 2D lat/lon grids. (:pr:`###`) `Riley X. Brady`_.
 
 Internals/Minor Fixes
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Features
 - ``loadutils`` removed (:pr:`52`) `Riley X. Brady`_.
 - ``calculate_compatible_emissions`` following Jones et al. 2013  (:pr:`54`) `Aaron Spring`_
 - Update ``corr`` to broadcast ``x`` and ``y`` such that a single time series can be correlated across a grid. (:pr:`58`) `Riley X. Brady`_.
-- ``convert_lon_to_180to180`` and ``convert_lon_to_0to360`` now wrapped with ``convert_lon`` and now supports 2D lat/lon grids. (:pr:`###`) `Riley X. Brady`_.
+- ``convert_lon_to_180to180`` and ``convert_lon_to_0to360`` now wrapped with ``convert_lon`` and now supports 2D lat/lon grids. ``convert_lon()`` is also available as an accessor.  (:pr:`60`) `Riley X. Brady`_.
 
 Internals/Minor Fixes
 ---------------------

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -22,7 +22,7 @@ dependencies:
   - nbsphinx
   - coveralls
   - importlib_metadata
-  - jupyterhub
+  - jupyterlab
   - pip
   - pip:
       - sphinxcontrib-napoleon

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -22,6 +22,7 @@ dependencies:
   - nbsphinx
   - coveralls
   - importlib_metadata
+  - jupyterhub
   - pip
   - pip:
       - sphinxcontrib-napoleon

--- a/docs/source/accessors.ipynb
+++ b/docs/source/accessors.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calling Functions via Accessors\n",
+    "\n",
+    "A subset of `esm_analysis` functions are registered as `xarray` accessors. What this means is that you can call some of these functions as you would `.isel()`, `.coarsen()`, `.interp()`, and so on with `xarray`.\n",
+    "\n",
+    "There is just one extra step to do so. After importing `esm_analysis`, you have to do add the module call after `ds` and then the function. For example, you can call `ds.grid.convert_lon()` to transform between -180 to 180 longitudes and 0 to 360 longitudes.\n",
+    "\n",
+    "**List of currently supported modules/functions.** *See the API for usage*.\n",
+    "\n",
+    "1. `grid`\n",
+    "    * convert_lon()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import esm_analysis\n",
+    "import numpy as np\n",
+    "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lat = np.linspace(-89.5, 89.5, 180)\n",
+    "lon = np.linspace(0.5, 359.5, 360)\n",
+    "empty = xr.DataArray(np.empty((180, 360)), dims=['lat', 'lon'])\n",
+    "data = xr.DataArray(np.linspace(0, 360, 360), dims=['lon'],)\n",
+    "data, _ = xr.broadcast(data, empty)\n",
+    "data = data.T\n",
+    "data['lon'] = lon\n",
+    "data['lat'] = lat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our sample data is just a plot of longitude."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.plot(x='lon', y='lat')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, it ranges from 0 to 360, which is sometimes problematic. We can use the accessor `convert_lon()` to convert this to -180 to 180. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(data.grid.convert_lon)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "converted = data.grid.convert_lon(coord='lon')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we've switched over to the -180 to 180 coordinate system. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "converted"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "converted.plot(x='lon', y='lat')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is equivalent to running the functional `convert_lon()` argument:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "converted = esm_analysis.grid.convert_lon(data, coord='lon')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "converted.plot(x='lon', y='lat')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -32,6 +32,7 @@ Functions related to climate model grids.
 .. automodsumm:: esm_analysis.grid
     :functions-only:
     :toctree: api
+    :skip: check_xarray
 
 MPAS Model Tools
 ~~~~~~~~~~~~~~~~

--- a/docs/source/api/esm_analysis.grid.convert_lon.rst
+++ b/docs/source/api/esm_analysis.grid.convert_lon.rst
@@ -1,0 +1,6 @@
+convert_lon
+===========
+
+.. currentmodule:: esm_analysis.grid
+
+.. autofunction:: convert_lon

--- a/docs/source/api/esm_analysis.grid.convert_lon_to_0to360.rst
+++ b/docs/source/api/esm_analysis.grid.convert_lon_to_0to360.rst
@@ -1,6 +1,0 @@
-convert_lon_to_0to360
-=====================
-
-.. currentmodule:: esm_analysis.grid
-
-.. autofunction:: convert_lon_to_0to360

--- a/docs/source/api/esm_analysis.grid.convert_lon_to_180to180.rst
+++ b/docs/source/api/esm_analysis.grid.convert_lon_to_180to180.rst
@@ -1,6 +1,0 @@
-convert_lon_to_180to180
-=======================
-
-.. currentmodule:: esm_analysis.grid
-
-.. autofunction:: convert_lon_to_180to180

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,13 +3,14 @@
 **Getting Started**
 
 * :doc:`examples`
-
+* :doc:`accessors`
 .. toctree::
     :maxdepth: 1
     :hidden:
     :caption: Getting Started
 
     examples
+    accessors
 
 **Help & Reference**
 

--- a/esm_analysis/__init__.py
+++ b/esm_analysis/__init__.py
@@ -1,5 +1,6 @@
 from pkg_resources import DistributionNotFound, get_distribution
 
+from .accessor import GridAccessor
 from . import (
     carbon,
     composite,

--- a/esm_analysis/accessor.py
+++ b/esm_analysis/accessor.py
@@ -1,0 +1,34 @@
+import xarray as xr
+
+from .grid import convert_lon
+
+
+@xr.register_dataarray_accessor('grid')
+@xr.register_dataset_accessor('grid')
+class GridAccessor:
+    """Allows functions to be called directly on an xarray dataset for the grid module.
+
+    This implementation was heavily inspired by @ahuang11's implementation to
+    xskillscore."""
+
+    def __init__(self, xarray_obj):
+        self._obj = xarray_obj
+
+    def convert_lon(self, coord='lon'):
+        """Converts longitude grid from -180to180 to 0to360 and vice versa.
+
+        .. note::
+            Longitudes are not sorted after conversion (i.e., spanning -180 to 180 or
+            0 to 360 from index 0, ..., N) if it is 2D.
+
+        Args:
+            ds (xarray object): Dataset to be converted.
+            coord (optional str): Name of longitude coordinate, defaults to 'lon'.
+
+        Returns:
+            xarray object: Dataset with converted longitude grid.
+
+        Raises:
+            CoordinateError: If ``coord`` does not exist in the dataset.
+        """
+        return convert_lon(self._obj, coord=coord)

--- a/esm_analysis/exceptions.py
+++ b/esm_analysis/exceptions.py
@@ -4,6 +4,14 @@ class Error(Exception):
     pass
 
 
+class CoordinateError(Error):
+    """Exception raised when the input xarray object doesn't have the
+    appropriate coordinates."""
+
+    def __init__(self, message):
+        self.message = message
+
+
 class DimensionError(Error):
     """Exception raised when the input xarray object doesn't have the
     appropriate dimensions."""

--- a/esm_analysis/grid.py
+++ b/esm_analysis/grid.py
@@ -1,28 +1,85 @@
+from .exceptions import CoordinateError
 from .utils import check_xarray
 
+# NOTE: Add testing
+# NOTE: Compile docs for new API. Delete old functions.
+
 
 @check_xarray(0)
-def convert_lon_to_180to180(ds, lon_coord='lon'):
-    """Convert from 0 to 360 grid to -180 to 180 grid."""
+def _convert_lon_to_180to180(ds, coord='lon'):
+    """Convert from 0 to 360 (degrees E) grid to -180 to 180 (W-E) grid.
+
+    .. note::
+        Longitudes are not sorted after conversion (i.e., spanning -180 to 180 or
+        0 to 360 from index 0, ..., N), as it is expected that the user will plot
+        via ``cartopy``, ``basemap``, or ``xarray`` plot functions.
+
+    Args:
+        ds (xarray object): Dataset to be converted.
+        coord (optional str): Name of longitude coordinate.
+
+    Returns:
+        xarray object: Dataset with converted longitude grid.
+    """
     ds = ds.copy()
-    lon = ds[lon_coord].values
+    lon = ds[coord].values
+    # Convert everything over 180 back to the negative (degrees W) values.
     lon[lon > 180] = lon[lon > 180] - 360
-    ds.coords[lon_coord] = lon
-    ds = ds.sortby(lon_coord)
+    # Need to account for clarifying dimensions if the grid is 2D.
+    ds.coords[coord] = (ds[coord].dims, lon)
     return ds
 
 
 @check_xarray(0)
-def convert_lon_to_0to360(ds, lon_coord='lon'):
-    """Convert from -180 to 180 grid to 0 to 360 grid."""
+def _convert_lon_to_0to360(ds, coord='lon'):
+    """Convert from -180 to 180 (W-E) to 0 to 360 (degrees E) grid.
+
+    .. note::
+        Longitudes are not sorted after conversion (i.e., spanning -180 to 180 or
+        0 to 360 from index 0, ..., N), as it is expected that the user will plot
+        via ``cartopy``, ``basemap``, or ``xarray`` plot functions.
+
+    Args:
+        ds (xarray object): Dataset to be converted.
+        coord (optional str): Name of longitude coordinate.
+
+    Returns:
+        xarray object: Dataset with converted longitude grid.
+    """
     ds = ds.copy()
-    lon = ds[lon_coord].values
+    lon = ds[coord].values
+    # Convert -180 to 0 into scale reaching 360.
     lon[lon < 0] = lon[lon < 0] + 360
-    ds.coords[lon_coord] = lon
-    ds = ds.sortby(lon_coord)
+    # Need to account for clarifying dimensions if the grid is 2D.
+    ds.coords[coord] = (ds[coord].dims, lon)
     return ds
 
 
+@check_xarray(0)
 def convert_lon(ds, coord='lon'):
-    """Will infer which longitude grid it's on"""
-    pass
+    """Converts longitude grid from -180to180 to 0to360 and vice versa.
+
+    .. note::
+        Longitudes are not sorted after conversion (i.e., spanning -180 to 180 or
+        0 to 360 from index 0, ..., N), as it is expected that the user will plot
+        via ``cartopy``, ``basemap``, or ``xarray`` plot functions.
+
+    Args:
+        ds (xarray object): Dataset to be converted.
+        coord (optional str): Name of longitude coordinate.
+
+    Returns:
+        xarray object: Dataset with converted longitude grid.
+
+    Raises:
+        CoordinateError: If ``coord`` does not exist in the dataset.
+    """
+    if coord not in ds.coords:
+        raise CoordinateError(f'{coord} not found in coordinates.')
+    # NOTE: Check weird POP grid that Eleanor sent. Could have a min less than 0
+    # and max greater than 180. Could just throw error then.
+    if ds[coord].min() < 0:
+        ds = _convert_lon_to_0to360(ds, coord=coord)
+    else:
+        ds = _convert_lon_to_180to180(ds, coord=coord)
+    return ds

--- a/esm_analysis/grid.py
+++ b/esm_analysis/grid.py
@@ -1,8 +1,8 @@
 from .exceptions import CoordinateError
 from .utils import check_xarray
 
-# NOTE: Add testing
-# NOTE: Compile docs for new API. Delete old functions.
+# NOTE: Check weird POP grid that Eleanor was struggling with. What happens there?
+# NOTE: Check how Andrew implemented accessor in xskillscore. Could do that here.
 
 
 @check_xarray(0)
@@ -73,11 +73,21 @@ def convert_lon(ds, coord='lon'):
 
     Raises:
         CoordinateError: If ``coord`` does not exist in the dataset.
+
+    Examples:
+       >>> import numpy as np
+       >>> import xarray as xr
+       >>> from esm_analysis.grid import convert_lon
+       >>> lat = np.linspace(-89.5, 89.5, 180)
+       >>> lon = np.linspace(0.5, 359.5, 360)
+       >>> empty = xr.DataArray(np.empty((180, 360)), dims=['lat', 'lon'])
+       >>> data = xr.DataArray(np.linspace(-180, 180, 360), dims=['lon'],)
+       >>> data, _ = xr.broadcast(data, empty)
+       >>> data = data.T
+       >>> converted = convert_lon(data, coord='lon')
     """
     if coord not in ds.coords:
         raise CoordinateError(f'{coord} not found in coordinates.')
-    # NOTE: Check weird POP grid that Eleanor sent. Could have a min less than 0
-    # and max greater than 180. Could just throw error then.
     if ds[coord].min() < 0:
         ds = _convert_lon_to_0to360(ds, coord=coord)
     else:

--- a/esm_analysis/grid.py
+++ b/esm_analysis/grid.py
@@ -1,6 +1,7 @@
-"""Definitions related to climate model grids."""
+from .utils import check_xarray
 
 
+@check_xarray(0)
 def convert_lon_to_180to180(ds, lon_coord='lon'):
     """Convert from 0 to 360 grid to -180 to 180 grid."""
     ds = ds.copy()
@@ -11,6 +12,7 @@ def convert_lon_to_180to180(ds, lon_coord='lon'):
     return ds
 
 
+@check_xarray(0)
 def convert_lon_to_0to360(ds, lon_coord='lon'):
     """Convert from -180 to 180 grid to 0 to 360 grid."""
     ds = ds.copy()
@@ -19,3 +21,8 @@ def convert_lon_to_0to360(ds, lon_coord='lon'):
     ds.coords[lon_coord] = lon
     ds = ds.sortby(lon_coord)
     return ds
+
+
+def convert_lon(ds, coord='lon'):
+    """Will infer which longitude grid it's on"""
+    pass

--- a/esm_analysis/tests/test_grid.py
+++ b/esm_analysis/tests/test_grid.py
@@ -82,7 +82,7 @@ def test_1D_0to360_to_180to180(da_1D):
     # But also accounts for coarser grids.
     assert (lonmin >= -180) & (lonmin <= 0) & (lonmax <= 180) & (lonmax >= 0)
     # Checks that data isn't changed.
-    assert np.allclose(data, converted)
+    assert np.allclose(data.mean(), converted.mean())
 
 
 def test_1D_180to180_to_0to360(da_1D):
@@ -94,7 +94,7 @@ def test_1D_180to180_to_0to360(da_1D):
     # Checks that it was appropriately converted, not going below 0 or above 360.
     assert (lonmin >= 0) & (lonmax <= 360)
     # Checks that data isn't changed.
-    assert np.allclose(data, converted)
+    assert np.allclose(data.mean(), converted.mean())
 
 
 def test_2D_0to360_to_180to180(da_2D):
@@ -107,7 +107,7 @@ def test_2D_0to360_to_180to180(da_2D):
     # But also accounts for coarser grids.
     assert (lonmin >= -180) & (lonmin <= 0) & (lonmax <= 180) & (lonmax >= 0)
     # Checks that data isn't changed.
-    assert np.allclose(data, converted)
+    assert np.allclose(data.mean(), converted.mean())
 
 
 def test_2D_180to180_to_0to360(da_2D):
@@ -119,7 +119,7 @@ def test_2D_180to180_to_0to360(da_2D):
     # Checks that it was appropriately converted, not going below 0 or above 360.
     assert (lonmin >= 0) & (lonmax <= 360)
     # Checks that data isn't changed.
-    assert np.allclose(data, converted)
+    assert np.allclose(data.mean(), converted.mean())
 
 
 def test_coordinate_error(da_1D):

--- a/esm_analysis/tests/test_grid.py
+++ b/esm_analysis/tests/test_grid.py
@@ -1,0 +1,132 @@
+import numpy as np
+import xarray as xr
+import pytest
+from esm_analysis.grid import convert_lon
+from esm_analysis.exceptions import CoordinateError
+
+
+@pytest.fixture()
+def da_1D():
+    """Gridded DataArray with one-dimensional lat and lon coordinates."""
+    # Wrapper so fixture can be called with arguments.
+    # https://alysivji.github.io/pytest-fixures-with-function-arguments.html
+    def _gen_data(degreesEast=None):
+        """Generate the DataArray.
+
+        degreesEast (bool): If True, create 0to360 longitude. If False, -180to180.
+        """
+        # Generate standard 1x1 deg lat/lon.
+        lat = np.linspace(-89.5, 89.5, 180)
+        if degreesEast:
+            lon = np.linspace(0.5, 359.5, 360)
+        elif not degreesEast:
+            lon = np.linspace(-179.5, 179.5, 360)
+        else:
+            raise ValueError('Please specify `degreesEast` as either True or False.')
+        # Template for broadcasting to
+        empty = xr.DataArray(
+            np.empty((180, 360)), dims=['lat', 'lon'], coords=[lat, lon]
+        )
+        # Data is roughly the longitude at each grid cell.
+        data = xr.DataArray(np.linspace(-180, 180, 360), dims=['lon'], coords=[lon])
+        # Simple broadcasting up to 180x360 dimensions.
+        data, _ = xr.broadcast(data, empty)
+        data = data.T
+        return data
+
+    return _gen_data
+
+
+@pytest.fixture()
+def da_2D():
+    """Gridded DataArray with two-dimensional lat and lon coordinates."""
+    # Wrapper so fixture can be called with arguments.
+    # https://alysivji.github.io/pytest-fixures-with-function-arguments.html
+    def _gen_data(degreesEast=None):
+        """Generate the DataArray.
+
+        degreesEast (bool): If True, create 0to360 longitude. If False, -180to180.
+        """
+        # Generate standard 1x1 deg lat/lon.
+        y = np.linspace(-89.5, 89.5, 180)
+        if degreesEast:
+            x = np.linspace(0.5, 359.5, 360)
+        elif not degreesEast:
+            x = np.linspace(-179.5, 179.5, 360)
+        else:
+            raise ValueError('Please specify `degreesEast` as either True or False.')
+        # Meshgrid into a 2-dimensional lon/lat.
+        lon, lat = np.meshgrid(x, y)
+        # Template for broadcasting to
+        empty = xr.DataArray(np.empty((180, 360)), dims=['y', 'x'])
+        # Data is roughly the longitude at each grid cell.
+        data = xr.DataArray(np.linspace(-180, 180, 360), dims=['x'])
+        # Simple broadcasting up to 180x360 dimensions.
+        data, _ = xr.broadcast(data, empty)
+        data = data.T
+        # Add 2D coordinates.
+        data['lon'] = (('y', 'x'), lon)
+        data['lat'] = (('y', 'x'), lat)
+        return data
+
+    return _gen_data
+
+
+def test_1D_0to360_to_180to180(da_1D):
+    """Tests that a 1D 0to360 grid converts to -180to180."""
+    data = da_1D(degreesEast=True)
+    converted = convert_lon(data)
+    lonmin = converted.lon.min()
+    lonmax = converted.lon.max()
+    # Checks that it was appropriately converted, not dipping below -180 or above 180.
+    # But also accounts for coarser grids.
+    assert (lonmin >= -180) & (lonmin <= 0) & (lonmax <= 180) & (lonmax >= 0)
+    # Checks that data isn't changed.
+    assert np.allclose(data, converted)
+
+
+def test_1D_180to180_to_0to360(da_1D):
+    """Tests that a 1D -180to180 grid converts to 0to360."""
+    data = da_1D(degreesEast=False)
+    converted = convert_lon(data)
+    lonmin = converted.lon.min()
+    lonmax = converted.lon.max()
+    # Checks that it was appropriately converted, not going below 0 or above 360.
+    assert (lonmin >= 0) & (lonmax <= 360)
+    # Checks that data isn't changed.
+    assert np.allclose(data, converted)
+
+
+def test_2D_0to360_to_180to180(da_2D):
+    """Tests that a 2D 0to360 grid converts to -180to180."""
+    data = da_2D(degreesEast=True)
+    converted = convert_lon(data)
+    lonmin = converted.lon.min()
+    lonmax = converted.lon.max()
+    # Checks that it was appropriately converted, not dipping below -180 or above 180.
+    # But also accounts for coarser grids.
+    assert (lonmin >= -180) & (lonmin <= 0) & (lonmax <= 180) & (lonmax >= 0)
+    # Checks that data isn't changed.
+    assert np.allclose(data, converted)
+
+
+def test_2D_180to180_to_0to360(da_2D):
+    """Tests that a 2D -180to180 grid converts to 0to360."""
+    data = da_2D(degreesEast=False)
+    converted = convert_lon(data)
+    lonmin = converted.lon.min()
+    lonmax = converted.lon.max()
+    # Checks that it was appropriately converted, not going below 0 or above 360.
+    assert (lonmin >= 0) & (lonmax <= 360)
+    # Checks that data isn't changed.
+    assert np.allclose(data, converted)
+
+
+def test_coordinate_error(da_1D):
+    """Tests that coordinate error is thrown when convert_lon is called and the
+    coordinate doesn't exist."""
+    data = da_1D(degreesEast=True)
+    with pytest.raises(CoordinateError) as e:
+        # Purposefully call nonexistant coordinate.
+        convert_lon(data, coord='foo')
+    assert 'not found in coordinates' in str(e.value)


### PR DESCRIPTION
# Description

This refactors the `grid` module to convert 0to360 longitudes to -180to180 and vice versa. It compresses these functions into one `convert_lon` function that infers which lon it needs to go to. 

This also registers `convert_lon()` as an accessor. Good opportunity for me to figure them out. I registered the accessor for `esm_analysis` as `esm`.

## Type of change

Please delete options that are not relevant.

-   [X]  New feature (non-breaking change which adds functionality)
expected)

# How Has This Been Tested?

Added a bunch of pytests to cover the whole `grid` module.

![Screen Shot 2019-08-31 at 12 34 46 AM](https://user-images.githubusercontent.com/8881170/64060245-c8ff4080-cb7e-11e9-8492-4c596c42bbb5.png)


## Checklist (while developing)

-   [X]  I have added docstrings to all new functions.
-   [X]  I have commented my code, particularly in hard-to-understand areas
-   [X]  Tests added for `pytest`, if necessary.
-   [X]  I have updated the sphinx documentation, if necessary.